### PR TITLE
Add support for slonik and @slonik/typegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pairs nicely with the following packages:
 - [`pg-lit`](https://www.npmjs.com/package/pg-lit)
 - [`postgres`](https://www.npmjs.com/package/postgres)
 - [`sql-template-strings`](https://www.npmjs.com/package/sql-template-strings)
+- [`slonik`](https://www.npmjs.com/package/slonik)
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Pairs nicely with the following packages:
 - [`postgres`](https://www.npmjs.com/package/postgres)
 - [`sql-template-strings`](https://www.npmjs.com/package/sql-template-strings)
 - [`slonik`](https://www.npmjs.com/package/slonik)
+- [`@slonik/typegen`](https://www.npmjs.com/package/@slonik/typegen)
 
 ## Samples
 

--- a/samples/index.ts
+++ b/samples/index.ts
@@ -12,7 +12,10 @@ const interpolated = sql`
    where "s"."one" = ${parseInt('1', 0)}
 `
 
-declare function sql<_>(strings: TemplateStringsArray, ...values: any[]): _
+declare const sql: {
+  <_>(strings: TemplateStringsArray, ...values: any[]): _
+  identifier: (names: string[]) => void;
+}
 
 const typed = sql<{ one: number }>`select 1 as "one"`
 
@@ -30,3 +33,8 @@ const plpgsql = sql`
     end;
   $$ language plpgsql;
 `
+
+const slonik = sql`
+  SELECT 1
+  FROM ${sql.identifier(['bar', 'baz'])}
+`;

--- a/samples/index.ts
+++ b/samples/index.ts
@@ -15,6 +15,7 @@ const interpolated = sql`
 declare const sql: {
   <_>(strings: TemplateStringsArray, ...values: any[]): _
   identifier: (names: string[]) => void;
+  Person: (strings: TemplateStringsArray, ...values: any[]) => void
 }
 
 const typed = sql<{ one: number }>`select 1 as "one"`
@@ -38,3 +39,5 @@ const slonik = sql`
   SELECT 1
   FROM ${sql.identifier(['bar', 'baz'])}
 `;
+
+const slonikTypegen = sql.Person`select * from person limit 2`;

--- a/syntaxes/sql-lit.json
+++ b/syntaxes/sql-lit.json
@@ -10,19 +10,19 @@
   "repository": {
     "sql-template-literal": {
       "name": "meta.embedded.block.sql",
-      "begin": "[sS][qQ][lL]\\s*(<.+>)?(\\s*`)",
+      "begin": "[sS][qQ][lL]\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?(\\s*`)",
       "beginCaptures": {
         "0": {
           "name": "entity.name.function.tagged-template.js"
         },
-        "1": {
+        "2": {
           "patterns": [
             {
               "include": "source.ts#type-arguments"
             }
           ]
         },
-        "2": {
+        "3": {
           "name": "punctuation.definition.string.template.begin.js string.template.js"
         }
       },


### PR DESCRIPTION
Add support for these libraries:
- [`slonik`](https://www.npmjs.com/package/slonik): works without any changes, only the samples and the docs are updated
- [`@slonik/typegen`](https://www.npmjs.com/package/@slonik/typegen): the grammar has to be updated slightly, to support this syntax:

  ```javascript
  sql.Person`select * from person limit 2`
  ```