### PR TITLE
Add support for new Slonik sql literal syntax

### DIFF
--- a/syntaxes/sql-lit.json
+++ b/syntaxes/sql-lit.json
@@ -10,7 +10,7 @@
   "repository": {
     "sql-template-literal": {
       "name": "meta.embedded.block.sql",
-      "begin": "[sS][qQ][lL]\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?(\\s*`)",
+      "begin": "[sS][qQ][lL]\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?(\\(.+\\))?(\\s*`)",
       "beginCaptures": {
         "0": {
           "name": "entity.name.function.tagged-template.js"

--- a/syntaxes/sql-lit.json
+++ b/syntaxes/sql-lit.json
@@ -23,6 +23,13 @@
           ]
         },
         "3": {
+          "patterns": [
+            {
+              "include": "source.ts"
+            }
+          ]
+        },
+        "4": {
           "name": "punctuation.definition.string.template.begin.js string.template.js"
         }
       },


### PR DESCRIPTION
This change supports syntax highlighting for new [Slonik sql literal syntax](https://github.com/gajus/slonik#user-content-slonik-runtime-validation-example-use-of-sql-type), i.e.:

```ts
sql.type(zodModel)`SELECT * From users;`;
```