### PR TITLE
Allow tags starting with sql* or db*

### DIFF
--- a/syntaxes/sql-lit.json
+++ b/syntaxes/sql-lit.json
@@ -10,7 +10,7 @@
   "repository": {
     "sql-template-literal": {
       "name": "meta.embedded.block.sql",
-      "begin": "[sS][qQ][lL]\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?(\\(.+\\))?(\\s*`)",
+      "begin": "(?i)(?:sql|db)\\w*\\s*(\\.[_$[:alpha:]][_$[:alnum:]]*)?\\s*(<.+>)?(\\(.+\\))?(\\s*`)",
       "beginCaptures": {
         "0": {
           "name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
Some developers prefer tagging SQL templates with `db`, or have to use multiple database connections like `sql1` and `sql2` etc. This PR allows the use of tags starting with sql and db (not just exactly matching them).

Examples:
```js
const taggedSql = sqlV1`SELECT * FROM foo`

const taggedDb = db`SELECT * FROM foo`
```
<img width="210" alt="Screenshot 2023-02-18 at 2 20 10 PM" src="https://user-images.githubusercontent.com/5615403/219901820-7d1837a0-00e5-4c60-b127-2a042cdc4c79.png">
